### PR TITLE
Fix wave protocol with orientation phase

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -46,6 +46,10 @@ pub enum NetworkMessageCode {
     AckGlobalMutex,
     /// Acknowledgment of the global mutex acquisition
     AckReleaseGlobalMutex,
+    /// Orientation phase before a wave diffusion
+    Orientation,
+    /// Orientation acknowledgment
+    OrientationAck,
 }
 
 #[cfg(feature = "server")]
@@ -94,6 +98,8 @@ pub enum MessageInfo {
     ReleaseMutex(ReleaseMutexPayload),
     /// Acknowledge a critical section
     AckMutex(AckMutexPayload),
+    /// Acknowledge orientation phase
+    OrientationAck(OrientationAckPayload),
     /// No payload
     None,
 }
@@ -115,6 +121,13 @@ pub struct ReleaseMutexPayload;
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct AckMutexPayload {
     pub clock: i64,
+}
+
+#[cfg(feature = "server")]
+/// Payload for the OrientationAck message
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
+pub struct OrientationAckPayload {
+    pub adopted: bool,
 }
 
 #[cfg(feature = "server")]


### PR DESCRIPTION
## Summary
- introduce `Orientation` and `OrientationAck` message types
- record children and pending messages for waves
- start waves through an orientation phase before diffusing
- update acquire/release mutex and critical commands to use the new logic

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68494a5c4b7883219edd297e42ec487e