### PR TITLE
Support multiple concurrent waves with wave_id

### DIFF
--- a/src/control.rs
+++ b/src/control.rs
@@ -187,6 +187,7 @@ pub async fn execute_critical(cmd: CriticalCommands) -> Result<(), Box<dyn std::
     };
 
     let msg;
+    let wave_id = format!("{}-{}", site_id, clock.get_lamport());
 
     match cmd {
         CriticalCommands::CreateUser { name } => {
@@ -201,6 +202,7 @@ pub async fn execute_critical(cmd: CriticalCommands) -> Result<(), Box<dyn std::
                 sender_id: site_id.to_string(),
                 message_initiator_id: site_id.to_string(),
                 message_initiator_addr: site_addr,
+                wave_id: wave_id.clone(),
             };
         }
         CriticalCommands::Deposit { name, amount } => {
@@ -223,6 +225,7 @@ pub async fn execute_critical(cmd: CriticalCommands) -> Result<(), Box<dyn std::
                 sender_id: site_id.to_string(),
                 message_initiator_id: site_id.to_string(),
                 message_initiator_addr: site_addr,
+                wave_id: wave_id.clone(),
             };
         }
         CriticalCommands::Withdraw { name, amount } => {
@@ -244,6 +247,7 @@ pub async fn execute_critical(cmd: CriticalCommands) -> Result<(), Box<dyn std::
                 sender_id: site_id.to_string(),
                 message_initiator_id: site_id.to_string(),
                 message_initiator_addr: site_addr,
+                wave_id: wave_id.clone(),
             };
         }
         CriticalCommands::Transfer { from, to, amount } => {
@@ -266,6 +270,7 @@ pub async fn execute_critical(cmd: CriticalCommands) -> Result<(), Box<dyn std::
                 sender_id: site_id.to_string(),
                 message_initiator_id: site_id.to_string(),
                 message_initiator_addr: site_addr,
+                wave_id: wave_id.clone(),
             };
         }
         CriticalCommands::Pay { name, amount } => {
@@ -288,6 +293,7 @@ pub async fn execute_critical(cmd: CriticalCommands) -> Result<(), Box<dyn std::
                 sender_id: site_id.to_string(),
                 message_initiator_id: site_id.to_string(),
                 message_initiator_addr: site_addr,
+                wave_id: wave_id.clone(),
             };
         }
         CriticalCommands::Refund {
@@ -312,6 +318,7 @@ pub async fn execute_critical(cmd: CriticalCommands) -> Result<(), Box<dyn std::
                 sender_id: site_id.to_string(),
                 message_initiator_id: site_id.to_string(),
                 message_initiator_addr: site_addr,
+                wave_id: wave_id.clone(),
             };
         }
         CriticalCommands::FileSnapshot => {
@@ -326,6 +333,7 @@ pub async fn execute_critical(cmd: CriticalCommands) -> Result<(), Box<dyn std::
                 sender_id: site_id.to_string(),
                 message_initiator_id: site_id.to_string(),
                 message_initiator_addr: site_addr,
+                wave_id: wave_id.clone(),
                 clock: clock.clone(),
             };
         }
@@ -341,6 +349,7 @@ pub async fn execute_critical(cmd: CriticalCommands) -> Result<(), Box<dyn std::
                 sender_id: site_id.to_string(),
                 message_initiator_id: site_id.to_string(),
                 message_initiator_addr: site_addr,
+                wave_id: wave_id.clone(),
                 clock: clock.clone(),
             };
         }
@@ -350,8 +359,8 @@ pub async fn execute_critical(cmd: CriticalCommands) -> Result<(), Box<dyn std::
         // initialisation des paramètres avant la diffusion d'un message
         let mut state = LOCAL_APP_STATE.lock().await;
         let nb_neigh = state.get_nb_connected_neighbours();
-        state.set_parent_addr(site_id.to_string(), site_addr);
-        state.set_nb_nei_for_wave(site_id.to_string(), nb_neigh);
+        state.set_parent_addr(wave_id.clone(), site_addr);
+        state.set_nb_nei_for_wave(wave_id.clone(), nb_neigh);
         nb_neigh > 0
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -220,6 +220,7 @@ async fn disconnect() {
             &site_id,
             &site_id,
             local_addr,
+            &format!("{}-{}", site_id, clock.get_lamport()),
             clock.clone(),
         )
         .await

--- a/src/message.rs
+++ b/src/message.rs
@@ -58,6 +58,8 @@ pub struct Message {
     pub message_initiator_id: String,
     /// Network address of the node that initiated the message
     pub message_initiator_addr: std::net::SocketAddr,
+    /// Unique identifier for the wave this message belongs to
+    pub wave_id: String,
     /// Network address of the sending node
     pub sender_addr: std::net::SocketAddr,
     /// Logical clock state of the sending node
@@ -275,6 +277,7 @@ mod tests {
             sender_addr: "127.0.0.1:8080".parse().unwrap(),
             message_initiator_id: "A".to_string(),
             message_initiator_addr: "127.0.0.1:8080".parse().unwrap(),
+            wave_id: "A-0".to_string(),
             clock: clock,
             command: None,
             info: MessageInfo::None,


### PR DESCRIPTION
## Summary
- add `wave_id` to `Message`
- track wave parent and neighbor counts keyed by `wave_id`
- include wave id in all messages and update state logic
- adapt mutex and control flows to generate unique wave ids
- update tests

## Testing
- `cargo test --locked --features server --no-run`
- `cargo test --features server`

------
https://chatgpt.com/codex/tasks/task_e_68497f5e0d548321af8b98c70684cac0