### PR TITLE
Add deterministic parent selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ git clone https://gitlab.utc.fr/guegathe/peillute.git -j8
 
 # To run a demo using CLI mode with debug logs:
 ./launch_peillute_instance.sh -debug -demo_cli
+
+# To run a demo with a simple tree topology (three nodes):
+./launch_peillute_instance.sh -demo_tree
 ```
 
 ### 3. Manually Install Dependencies

--- a/launch_peillute_instance.sh
+++ b/launch_peillute_instance.sh
@@ -181,6 +181,24 @@ run_unique_cycle_demo() {
     fi
 }
 
+# Function to run a simple tree demo (three nodes, no cycle)
+run_tree_demo() {
+    echo "[*] Running the Peillute tree demo..."
+    cd target/dx/peillute/release/web
+
+    if [ "$(uname)" == "Darwin" ]; then
+        # macOS
+        osascript -e "tell app \"Terminal\" to do script \"cd $(pwd) && RUST_LOG=$LOG_LEVEL ./server --cli-port 10001 --cli-peers 127.0.0.1:10002,127.0.0.1:10003 --cli-db-id 0\""
+        osascript -e "tell app \"Terminal\" to do script \"cd $(pwd) && RUST_LOG=$LOG_LEVEL ./server --cli-port 10002 --cli-peers 127.0.0.1:10001 --cli-db-id 1\""
+        osascript -e "tell app \"Terminal\" to do script \"cd $(pwd) && RUST_LOG=$LOG_LEVEL ./server --cli-port 10003 --cli-peers 127.0.0.1:10001 --cli-db-id 2\""
+    else
+        # Linux
+        gnome-terminal -- bash -c "cd $(pwd) && RUST_LOG=$LOG_LEVEL ./server --cli-port 10001 --cli-peers 127.0.0.1:10002,127.0.0.1:10003 --cli-db-id 0; exec bash"
+        gnome-terminal -- bash -c "cd $(pwd) && RUST_LOG=$LOG_LEVEL ./server --cli-port 10002 --cli-peers 127.0.0.1:10001 --cli-db-id 1; exec bash"
+        gnome-terminal -- bash -c "cd $(pwd) && RUST_LOG=$LOG_LEVEL ./server --cli-port 10003 --cli-peers 127.0.0.1:10001 --cli-db-id 2; exec bash"
+    fi
+}
+
 
 # Function to run demo
 run_line_demo() {
@@ -292,6 +310,10 @@ for arg in "$@"; do
     fi
     if [ "$arg" == "-demo_cycle" ]; then
         run_unique_cycle_demo
+        exit 0
+    fi
+    if [ "$arg" == "-demo_tree" ]; then
+        run_tree_demo
         exit 0
     fi
     if [ "$arg" == "-demo_cli" ]; then

--- a/src/network.rs
+++ b/src/network.rs
@@ -259,24 +259,13 @@ pub async fn handle_network_message(
                         .unwrap_or(&"0.0.0.0:0".parse().unwrap())
                         .to_string();
                     if parent_id == "0.0.0.0:0" {
-                        state.set_parent_addr(
+                        let nb = state.init_parent_for_wave(
                             message.message_initiator_id.clone(),
                             message.sender_addr,
                         );
-
-                        let nb_neighbours = state.get_nb_connected_neighbours();
-                        let current_value = state
-                            .attended_neighbours_nb_for_transaction_wave
-                            .get(&message.message_initiator_id)
-                            .copied()
-                            .unwrap_or(nb_neighbours);
-
-                        state
-                            .attended_neighbours_nb_for_transaction_wave
-                            .insert(message.message_initiator_id.clone(), current_value - 1);
-
-                        log::debug!("Nombre de voisin : {}", current_value - 1);
-
+                        log::debug!("Nombre de voisin : {}", nb);
+                        diffuse = nb > 0;
+                    } else {
                         diffuse = state
                             .attended_neighbours_nb_for_transaction_wave
                             .get(&message.message_initiator_id)
@@ -492,24 +481,13 @@ pub async fn handle_network_message(
                         .unwrap_or(&"0.0.0.0:0".parse().unwrap())
                         .to_string();
                     if parent_id == "0.0.0.0:0" {
-                        state.set_parent_addr(
+                        let nb = state.init_parent_for_wave(
                             message.message_initiator_id.clone(),
                             message.sender_addr,
                         );
-
-                        let nb_neighbours = state.get_nb_connected_neighbours();
-                        let current_value = state
-                            .attended_neighbours_nb_for_transaction_wave
-                            .get(&message.message_initiator_id)
-                            .copied()
-                            .unwrap_or(nb_neighbours);
-
-                        state
-                            .attended_neighbours_nb_for_transaction_wave
-                            .insert(message.message_initiator_id.clone(), current_value - 1);
-
-                        log::debug!("Nombre de voisin : {}", current_value - 1);
-
+                        log::debug!("Nombre de voisin : {}", nb);
+                        diffuse = nb > 0;
+                    } else {
                         diffuse = state
                             .attended_neighbours_nb_for_transaction_wave
                             .get(&message.message_initiator_id)
@@ -663,24 +641,13 @@ pub async fn handle_network_message(
                             .unwrap_or(&"0.0.0.0:0".parse().unwrap())
                             .to_string();
                         if parent_id == "0.0.0.0:0" {
-                            state.set_parent_addr(
+                            let nb = state.init_parent_for_wave(
                                 message.message_initiator_id.clone(),
                                 message.sender_addr,
                             );
-
-                            let nb_neighbours = state.get_nb_connected_neighbours();
-                            let current_value = state
-                                .attended_neighbours_nb_for_transaction_wave
-                                .get(&message.message_initiator_id)
-                                .copied()
-                                .unwrap_or(nb_neighbours);
-
-                            state
-                                .attended_neighbours_nb_for_transaction_wave
-                                .insert(message.message_initiator_id.clone(), current_value - 1);
-
-                            log::debug!("Nombre de voisin : {}", current_value - 1);
-
+                            log::debug!("Nombre de voisin : {}", nb);
+                            diffuse = nb > 0;
+                        } else {
                             diffuse = state
                                 .attended_neighbours_nb_for_transaction_wave
                                 .get(&message.message_initiator_id.clone())


### PR DESCRIPTION
## Summary
- maintain a static parent address for each node to avoid cycles
- compute parent whenever a new neighbour is added
- initialise wave parent using this deterministic parent

## Testing
- `cargo fmt --all`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68498a2cdfcc832195193709a6d067d2